### PR TITLE
feat: Add navigation buttons to the shopping list creation page

### DIFF
--- a/frontend/src/pages/ShoppingListPage.tsx
+++ b/frontend/src/pages/ShoppingListPage.tsx
@@ -15,6 +15,11 @@ export default function ShoppingListPage(){
         navigate("/shopping/" + id)
     };
 
+    const handleSaveAndGoHomeButtonClick = () => {
+        // Add POST API call here
+        navigate("/")
+    };
+
     const navigate = useNavigate();
 
     const handleSubmitNewItem = (item: Item, quantity: string) => {
@@ -37,12 +42,20 @@ export default function ShoppingListPage(){
             <ItemForm onSubmit={handleSubmitNewItem}
             />
             <GroupedItems items={items} checkbox={false}/>
+            <div className="flex justify-center">
+            <button
+                onClick={() => handleSaveAndGoHomeButtonClick()}
+                className="px-4 py-2 text-sm text-white bg-blue-500 rounded-md hover:bg-blue-600"
+            >
+                Save and go 🏠
+            </button>
             <button
                 onClick={() => handleGoShoppingButtonClick()}
-                className="px-4 py-2 text-sm text-white bg-blue-500 rounded-md hover:bg-blue-600"
+                className="ml-4 px-4 py-2 text-sm text-white bg-blue-500 rounded-md hover:bg-blue-600"
             >
                 Save and go 🛒
             </button>
+            </div>
         </div>
     );
 

--- a/frontend/src/pages/ShoppingListPage.tsx
+++ b/frontend/src/pages/ShoppingListPage.tsx
@@ -8,6 +8,8 @@ export default function ShoppingListPage(){
 
     const [items, setItems] = useState<{item: Item, quantity: string}[]>([]);
 
+    const [shoppingListName, setShoppingListName] = useState("");
+
     const handleGoShoppingButtonClick = () => {
         const id: string = ""  // Get this from the POST API call
         navigate("/shopping/" + id)
@@ -23,6 +25,15 @@ export default function ShoppingListPage(){
     return (
         <div className="shopping-list-page">
             Shopping List Page
+            <div className="relative rounded-md border border-gray-300">
+                <input type="text"
+                       id="shoppingListName"
+                       name="shoppingListName"
+                       value={shoppingListName}
+                       onChange={(e) => setShoppingListName(e.target.value)} required
+                       placeholder="Shopping List Name"
+                       className="w-full py-2 pl-3 text-sm rounded-md focus:outline-none dark:bg-gray-100 dark:text-gray-800 focus:dark:bg-gray-50 focus:dark:border-blue-600"/>
+            </div>
             <ItemForm onSubmit={handleSubmitNewItem}
             />
             <GroupedItems items={items} checkbox={false}/>

--- a/frontend/src/pages/ShoppingListPage.tsx
+++ b/frontend/src/pages/ShoppingListPage.tsx
@@ -2,13 +2,20 @@ import ItemForm from "../components/ItemForm.tsx";
 import {Item} from "../type/Item.tsx";
 import {useState} from "react";
 import GroupedItems from "../components/GroupedItems.tsx";
+import {useNavigate} from "react-router-dom";
 
 export default function ShoppingListPage(){
 
     const [items, setItems] = useState<{item: Item, quantity: string}[]>([]);
 
-    const handleSubmitNewItem = (item: Item, quantity: string) => {
+    const handleGoShoppingButtonClick = () => {
+        const id: string = ""  // Get this from the POST API call
+        navigate("/shopping/" + id)
+    };
 
+    const navigate = useNavigate();
+
+    const handleSubmitNewItem = (item: Item, quantity: string) => {
         setItems([...items, {item, quantity}]);
         console.log(items);
     };
@@ -19,6 +26,12 @@ export default function ShoppingListPage(){
             <ItemForm onSubmit={handleSubmitNewItem}
             />
             <GroupedItems items={items} checkbox={false}/>
+            <button
+                onClick={() => handleGoShoppingButtonClick()}
+                className="px-4 py-2 text-sm text-white bg-blue-500 rounded-md hover:bg-blue-600"
+            >
+                Save and go 🛒
+            </button>
         </div>
     );
 

--- a/frontend/src/pages/ShoppingListPage.tsx
+++ b/frontend/src/pages/ShoppingListPage.tsx
@@ -10,6 +10,8 @@ export default function ShoppingListPage(){
 
     const [shoppingListName, setShoppingListName] = useState("");
 
+    const navigate = useNavigate();
+
     const handleGoShoppingButtonClick = () => {
         const id: string = ""  // Get this from the POST API call
         navigate("/shopping/" + id)
@@ -19,9 +21,7 @@ export default function ShoppingListPage(){
         // Add POST API call here
         navigate("/")
     };
-
-    const navigate = useNavigate();
-
+    
     const handleSubmitNewItem = (item: Item, quantity: string) => {
         setItems([...items, {item, quantity}]);
         console.log(items);

--- a/frontend/src/pages/ShoppingListPage.tsx
+++ b/frontend/src/pages/ShoppingListPage.tsx
@@ -1,6 +1,6 @@
 import ItemForm from "../components/ItemForm.tsx";
 import {Item} from "../type/Item.tsx";
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import GroupedItems from "../components/GroupedItems.tsx";
 import {useNavigate} from "react-router-dom";
 
@@ -21,11 +21,14 @@ export default function ShoppingListPage(){
         // Add POST API call here
         navigate("/")
     };
-    
+
     const handleSubmitNewItem = (item: Item, quantity: string) => {
         setItems([...items, {item, quantity}]);
-        console.log(items);
     };
+
+    useEffect(() => {
+        console.log(items);
+    }, [items]);  // every time the state of items change, the items will be logged
 
     return (
         <div className="shopping-list-page">


### PR DESCRIPTION
Closes: #34
Closes: #12

With this PR, two buttons are added to the shopping list creation page:
- one to save the list and go back to the home
- one to save the list and go to the shopping page

![image](https://github.com/user-attachments/assets/499b636c-f394-4048-ad14-430c63f09818)
